### PR TITLE
pymorphy3 1.2.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+upload_channels:
+  - sk_test
+channels:
+  - sk_test

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,0 @@
-upload_channels:
-  - sk_test
-channels:
-  - sk_test

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,3 @@
-aggregate_check: false
 upload_channels:
   - sk_test
 channels:

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,4 @@
+aggregate_check: false
 upload_channels:
   - sk_test
 channels:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,10 +10,10 @@ source:
   sha256: 322b7de091ea8ab35d5441f981f5ffbe39334e4a9326aefd247ebb2642233781
 
 build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - pymorphy = pymorphy3.cli:main
-  script: {{ PYTHON }} -m pip install . -vv
-  number: 0
 
 requirements:
   host:
@@ -25,21 +25,27 @@ requirements:
     - python
     - dawg-python >=0.7.1
     - docopt >=0.6
-    - pymorphy3-dicts-ru
+    - pymorphy3-dicts-uk
 
 test:
   imports:
     - pymorphy3
+  #requires:
+  #  - pip
   commands:
-    - pip check
+    # the package has uk dictionaries instead of ru dicts
+    #- pip check
     - pymorphy --help
-  requires:
-    - pip
 
 about:
   home: https://github.com/no-plagiarism/pymorphy3
-  summary: Morphological analyzer (POS tagger + inflection engine) for Russian language.
+  dev_url: https://github.com/no-plagiarism/pymorphy3
+  doc_url: https://github.com/no-plagiarism/pymorphy3
+  summary: Morphological analyzer (POS tagger + inflection engine) for Ukrainian language.
+  description: |
+    Morphological analyzer (POS tagger + inflection engine) for Ukrainian language.
   license: MIT
+  license_family: MIT
   license_file: LICENSE.txt
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,16 +25,17 @@ requirements:
     - python
     - dawg-python >=0.7.1
     - docopt >=0.6
+    - pymorphy3-dicts-ru
+    # add uk dictionaries too
     - pymorphy3-dicts-uk
 
 test:
   imports:
     - pymorphy3
-  #requires:
-  #  - pip
+  requires:
+    - pip
   commands:
-    # the package has uk dictionaries instead of ru dicts
-    #- pip check
+  - pip check
     - pymorphy --help
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,16 +35,16 @@ test:
   requires:
     - pip
   commands:
-  - pip check
+    - pip check
     - pymorphy --help
 
 about:
   home: https://github.com/no-plagiarism/pymorphy3
   dev_url: https://github.com/no-plagiarism/pymorphy3
   doc_url: https://github.com/no-plagiarism/pymorphy3
-  summary: Morphological analyzer (POS tagger + inflection engine) for Ukrainian language.
+  summary: Morphological analyzer (POS tagger + inflection engine) for Ukrainian and Russian languages.
   description: |
-    Morphological analyzer (POS tagger + inflection engine) for Ukrainian language.
+    Morphological analyzer (POS tagger + inflection engine) for Ukrainian and Russian languages.
   license: MIT
   license_family: MIT
   license_file: LICENSE.txt


### PR DESCRIPTION
License: https://github.com/no-plagiarism/pymorphy3/blob/1.2.0/LICENSE.txt
Requirements: 
- https://github.com/no-plagiarism/pymorphy3/blob/1.2.0/setup.py

Actions:
1. We add `pymorphy3-dicts-uk` to `run` because it's also supported, see https://github.com/no-plagiarism/pymorphy3/blob/1d9c310c3f7951ee40e21a85aacb6deadaf10381/setup.py#L63 and https://github.com/conda-forge/spacy-models-feedstock/issues/2#issuecomment-1413085954

Notes:
- it's needed for resolving this issue https://github.com/conda-forge/spacy-models-feedstock/issues/2